### PR TITLE
Add VERSION to Earthfile + upgrade Ubuntu version

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,5 +1,7 @@
+VERSION 0.6
+
 deps:
-    FROM ubuntu:20.10
+    FROM ubuntu:22.10
     RUN apt-get update && apt-get install -y python3 python3-pip
     RUN pip3 install matplotlib
 


### PR DESCRIPTION
- Version is now required for Earthly it seems like. It refused to run before I added it.
- Dependencies wouldn't install. Upgrading the Ubuntu version did the trick.